### PR TITLE
Adds default keywords to new pack template

### DIFF
--- a/templates/pack/package.json
+++ b/templates/pack/package.json
@@ -15,6 +15,19 @@
     "type": "git",
     "url": ""
   },
+  "keywords": [
+    "bem",
+    "css",
+    "design",
+    "functional",
+    "itcss",
+    "modular",
+    "oocss",
+    "performance",
+    "seed",
+    "seed-pack",
+    "scss"
+  ],
   "authors": [
   ],
   "license": "<%= license %>",


### PR DESCRIPTION
Adds keywords. `seed-pack` will be the approach we'll take moving forward to make it easy to search npm for seed packs.
