### PR TITLE
Fixes utility directory name on generate

### DIFF
--- a/commands/generate/generate.js
+++ b/commands/generate/generate.js
@@ -37,7 +37,7 @@ var parseModule = function(options) {
     if (type === 'utility') {
       type = 'utilities';
     }
-    if (type === 'test') {
+    else if (type === 'test') {
       type = 'test';
     }
     else {


### PR DESCRIPTION
Adjusts if/else condition to prevent it from adding an extra "s" at the end of "utilities"
