### PR TITLE
Node update version to 0.12

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,25 +1,11 @@
+'use strict';
+
 // Seed CLI :: CLI
 
 var meow = require('meow');
 var pkg = require('../package');
 
-var cli = meow(`
-  Usage:
-    seed <command>
-
-  Commands:
-    n, new          Creates a new Seed pack
-    g, generate     Creates a new .scss module (component/object/scope/test/utility)
-
-  Options:
-    -c, --config    Custom sass-lint config (.yml)
-    -i, --ignore    Ignore files for linting/testing
-    -l, --lint      Initialize .scss lint (powered by sass-lint)
-    -t, --test      Initialize tests (powered by mocha + sass-true)
-
-  ${pkg.name} v${pkg.version}
-  Website: ${pkg.homepage}
-`, {
+var cli = meow('\n  Usage:\n    seed <command>\n\n  Commands:\n    n, new          Creates a new Seed pack\n    g, generate     Creates a new .scss module (component/object/scope/test/utility)\n\n  Options:\n    -c, --config    Custom sass-lint config (.yml)\n    -i, --ignore    Ignore files for linting/testing\n    -l, --lint      Initialize .scss lint (powered by sass-lint)\n    -t, --test      Initialize tests (powered by mocha + sass-true)\n\n  ' + pkg.name + ' v' + pkg.version + '\n  Website: ' + pkg.homepage + '\n', {
   alias: {
     c: 'config',
     i: 'ignore',

--- a/commands/generate/config.js
+++ b/commands/generate/config.js
@@ -1,4 +1,5 @@
 // Commands :: Generate :: Config
+'use strict';
 
 var _ = require('lodash');
 

--- a/commands/generate/generate.js
+++ b/commands/generate/generate.js
@@ -9,7 +9,7 @@ var mkdirp = require('mkdirp');
 var path = require('path');
 var prompt = require('./prompt');
 
-var parseOptions = function(options) {
+var parseOptions = function parseOptions(options) {
   if (!options) {
     return false;
   }
@@ -17,13 +17,12 @@ var parseOptions = function(options) {
 
   if (options.type === 'test') {
     return parseTest(options);
-  }
-  else {
+  } else {
     return parseModule(options);
   }
 };
 
-var parseModule = function(options) {
+var parseModule = function parseModule(options) {
   if (!options) {
     return false;
   }
@@ -36,14 +35,12 @@ var parseModule = function(options) {
     var type = options.type;
     if (type === 'utility') {
       type = 'utilities';
-    }
-    else if (type === 'test') {
+    } else if (type === 'test') {
       type = 'test';
+    } else {
+      type = type + 's';
     }
-    else {
-      type = `${ type }s`;
-    }
-    options.dest = `${ type }/${ options.dest }`;
+    options.dest = type + '/' + options.dest;
   }
 
   options.templateFiles = fs.readdirSync(options.templateDir);
@@ -51,7 +48,7 @@ var parseModule = function(options) {
   return options;
 };
 
-var parseTest = function(options) {
+var parseTest = function parseTest(options) {
   if (!options) {
     return false;
   }
@@ -59,15 +56,14 @@ var parseTest = function(options) {
   options.name = options.name.replace('seed-', '');
   options.dest = 'test';
   options.templateDir = global.templateDir + 'test/';
-  options.templateFiles = [ 'test.scss' ];
+  options.templateFiles = ['test.scss'];
 
   return options;
 };
 
-
-var generate = function(options) {
+var generate = function generate(options) {
   if (!options) {
-    process.exit(1)
+    process.exit(1);
     return false;
   }
 
@@ -75,9 +71,9 @@ var generate = function(options) {
 
   mkdirp.sync(options.dest);
 
-  console.log(`Generating your new ${ options.type }…\n`);
+  console.log('Generating your new ' + options.type + '…\n');
 
-  _.forEach(options.templateFiles, function(file) {
+  _.forEach(options.templateFiles, function (file) {
     var template = fs.readFileSync(options.templateDir + file, 'utf8');
     var outputFile = file;
 
@@ -86,11 +82,11 @@ var generate = function(options) {
     }
 
     fs.writeFileSync(options.dest + '/' + outputFile, _.template(template)(options));
-    console.log(`    created  ${ options.dest + '/' + outputFile }`);
+    console.log('    created  ' + (options.dest + '/' + outputFile));
   });
 
-  console.log(`\nCongrats! Your new .scss ${ options.type } has been created.`);
-  process.exit(0)
+  console.log('\nCongrats! Your new .scss ' + options.type + ' has been created.');
+  process.exit(0);
 };
 
 module.exports = generate;

--- a/commands/generate/help.js
+++ b/commands/generate/help.js
@@ -1,27 +1,6 @@
 // Commands :: Generate :: Help
+"use strict";
 
-var help = `
-  Generate .scss modules with Seed!
-
-  Usage:
-    seed generate <type> <name>
-
-  Type:
-    c, component
-    o, object
-    s, scope
-    t, test
-    u, utility
-
-  Name:
-    This will be used as your module's class name
-
-  Example:
-    seed generate component awesome
-
-    Will result in a class name of .c-awesome.
-
-  Happy generating!
-`;
+var help = "\n  Generate .scss modules with Seed!\n\n  Usage:\n    seed generate <type> <name>\n\n  Type:\n    c, component\n    o, object\n    s, scope\n    t, test\n    u, utility\n\n  Name:\n    This will be used as your module's class name\n\n  Example:\n    seed generate component awesome\n\n    Will result in a class name of .c-awesome.\n\n  Happy generating!\n";
 
 module.exports = help;

--- a/commands/new/generate.js
+++ b/commands/new/generate.js
@@ -9,14 +9,14 @@ var mkdirp = require('mkdirp');
 var cli = global.cli;
 var templateDir = global.templateDir + 'pack/';
 
-var isFile = function(file) {
+var isFile = function isFile(file) {
   if (!file) {
     return false;
   }
   return fs.statSync(file).isFile();
 };
 
-var copyFile = function(dest, options, file, output) {
+var copyFile = function copyFile(dest, options, file, output) {
   if (!file) {
     return false;
   }
@@ -25,30 +25,30 @@ var copyFile = function(dest, options, file, output) {
   var template = fs.readFileSync(templateDir + file, 'utf8');
   fs.writeFileSync(dest + '/' + output, _.template(template)(options));
 
-  return console.log(`    created  ${ dest + '/' + output }`);
+  return console.log('    created  ' + (dest + '/' + output));
 };
 
-var copyDirectoryFiles = function(dest, options) {
+var copyDirectoryFiles = function copyDirectoryFiles(dest, options) {
   var config = fs.readFileSync(templateDir + 'scss/pack/_config.scss', 'utf8');
   var scss = fs.readFileSync(templateDir + 'scss/pack/_seed-starter.scss', 'utf8');
   var banner = fs.readFileSync(templateDir + 'scripts/banner.js', 'utf8');
   var build = fs.readFileSync(templateDir + 'scripts/build.js', 'utf8');
   var test = fs.readFileSync(templateDir + 'scripts/test.js', 'utf8');
 
-  fs.writeFileSync(dest + `/scss/pack/_config.scss`, _.template(config)(options));
-  fs.writeFileSync(dest + `/scss/pack/_${ options.packName }.scss`, _.template(scss)(options));
-  fs.writeFileSync(dest + `/scripts/banner.js`, _.template(banner)(options));
-  fs.writeFileSync(dest + `/scripts/build.js`, _.template(build)(options));
-  fs.writeFileSync(dest + `/scripts/test.js`, _.template(test)(options));
+  fs.writeFileSync(dest + '/scss/pack/_config.scss', _.template(config)(options));
+  fs.writeFileSync(dest + ('/scss/pack/_' + options.packName + '.scss'), _.template(scss)(options));
+  fs.writeFileSync(dest + '/scripts/banner.js', _.template(banner)(options));
+  fs.writeFileSync(dest + '/scripts/build.js', _.template(build)(options));
+  fs.writeFileSync(dest + '/scripts/test.js', _.template(test)(options));
 
-  console.log(`    created  ${ dest }/scss/pack/_config.scss`);
-  console.log(`    created  ${ dest }/scss/pack/_${ options.name }.scss`);
-  console.log(`    created  ${ dest }/scripts/banner.js`);
-  console.log(`    created  ${ dest }/scripts/build.js`);
-  console.log(`    created  ${ dest }/scripts/test.js`);
+  console.log('    created  ' + dest + '/scss/pack/_config.scss');
+  console.log('    created  ' + dest + '/scss/pack/_' + options.name + '.scss');
+  console.log('    created  ' + dest + '/scripts/banner.js');
+  console.log('    created  ' + dest + '/scripts/build.js');
+  console.log('    created  ' + dest + '/scripts/test.js');
 };
 
-var generate = function(dest, options) {
+var generate = function generate(dest, options) {
   if (!dest) {
     return false;
   }
@@ -58,7 +58,7 @@ var generate = function(dest, options) {
   copyDirectoryFiles(dest, options);
 
   var templateFiles = fs.readdirSync(templateDir);
-  _.forEach(templateFiles, function(file) {
+  _.forEach(templateFiles, function (file) {
     // Generate files
     if (isFile(templateDir + file)) {
       var output = file;

--- a/commands/new/index.js
+++ b/commands/new/index.js
@@ -16,11 +16,10 @@ var command = global.cli.input[0];
 
 var generate = require('./generate');
 
-if (((command === 'new' || command === 'n') && isEmpty(global.cli.flags)) || global.cli.flags.new) {
+if ((command === 'new' || command === 'n') && isEmpty(global.cli.flags) || global.cli.flags.new) {
 
-  prompt()
-  .then(function(options) {
-    console.log('Generating your new Seed pack…\n')
+  prompt().then(function (options) {
+    console.log('Generating your new Seed pack…\n');
 
     options.packName = 'seed-' + options.name;
 
@@ -36,10 +35,10 @@ if (((command === 'new' || command === 'n') && isEmpty(global.cli.flags)) || glo
     git(dest);
     console.log('Git has been setup!');
 
-    console.log(`\nCongrats! Your new Seed pack has been created.\n`);
+    console.log('\nCongrats! Your new Seed pack has been created.\n');
     console.log(chalk.yellow('Don\'t forget to run npm install'));
     console.log(chalk.green('Happy coding <3'));
 
-    process.exit(0)
+    process.exit(0);
   });
 }

--- a/commands/test/index.js
+++ b/commands/test/index.js
@@ -23,29 +23,26 @@ var testCache = root + '/.seed-test-cache';
 var testDir = 'test';
 
 var options = {
-  ignore: [
-    'bower_components/**/*',
-    'node_modules/**/*'
-  ]
+  ignore: ['bower_components/**/*', 'node_modules/**/*']
 };
 
-var clean = function() {
+var clean = function clean() {
   return del(testCache, { force: true });
 };
 
-var getTestFileName = function(file) {
+var getTestFileName = function getTestFileName(file) {
   return path.basename(file).replace(/_/g, '').replace('.scss', '') + '-' + uuid.v1() + '.js';
 };
 
 // Delete the test cache directory (just in case it was left over)
 clean();
 
-glob('**/*.scss', options, function(err, matches) {
+glob('**/*.scss', options, function (err, matches) {
   var files = matches;
   var currentDir = process.cwd().split('/').pop();
 
   if (currentDir !== testDir) {
-    files = files.filter(function(file) {
+    files = files.filter(function (file) {
       var dir = testDir + '/';
       return file.indexOf(dir) >= 0;
     });
@@ -54,12 +51,12 @@ glob('**/*.scss', options, function(err, matches) {
   mkdirp.sync(testCache);
 
   if (!files.length) {
-    console.log(`\nCouldn't find any tests in your project!`);
-    console.log(`You can create a new test by executing "seed g"\n`);
-    process.exit(0)
+    console.log('\nCouldn\'t find any tests in your project!');
+    console.log('You can create a new test by executing "seed g"\n');
+    process.exit(0);
   }
 
-  _.forEach(files, function(file) {
+  _.forEach(files, function (file) {
     var dest = testCache + '/' + getTestFileName(file);
     var options = {
       file: file
@@ -70,10 +67,10 @@ glob('**/*.scss', options, function(err, matches) {
     mocha.addFile(dest);
   });
 
-  mocha.run(function(failures){
+  mocha.run(function (failures) {
     // Delete test cache redirectory
     clean();
-    process.on('exit', function() {
+    process.on('exit', function () {
       process.exit(failures);
     });
   });

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "seed": "./index.js"
   },
+  "engines": {
+    "node": ">=0.10.0"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "seed": "./index.js"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/templates/pack/.travis.yml
+++ b/templates/pack/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10.0"
+  - "0.12.0"
 
 branches:
   only:

--- a/templates/pack/.travis.yml
+++ b/templates/pack/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "5.0"
+  - "0.10.0"
 
 branches:
   only:

--- a/templates/pack/package.json
+++ b/templates/pack/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "<%= license %>",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0"
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",

--- a/templates/pack/package.json
+++ b/templates/pack/package.json
@@ -31,7 +31,7 @@
   ],
   "license": "<%= license %>",
   "engines": {
-    "node": ">=0.10.1"
+    "node": ">=0.10.0"
   },
   "devDependencies": {
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
- Updates node version to use 0.12
- Updates node engine and travis node version in pack template to 0.12
- Updates scripts to be ES5 compatible

TODO:
Probably a good idea to use [commander](https://github.com/tj/commander.js/) for the CLI logs
