### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/commands/test/index.js
+++ b/commands/test/index.js
@@ -12,7 +12,7 @@ var fs = require('fs');
 var glob = require('glob');
 var mkdirp = require('mkdirp');
 var path = require('path');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var Mocha = require('mocha');
 var mocha = new Mocha();

--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
     "mocha": "^3.0.2",
-    "node-uuid": "^1.4.7",
     "require-dir": "^0.3.0",
     "sass-lint": "^1.9.1",
     "sass-true": "^2.1.3",
-    "shelljs": "^0.7.4"
+    "shelljs": "^0.7.4",
+    "uuid": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.